### PR TITLE
Rewrite dicom2vtk. Batch dicom2vtk bash script.

### DIFF
--- a/dicom-to-vti/python/batch_dicom2vtk
+++ b/dicom-to-vti/python/batch_dicom2vtk
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+INPUT_DIR=${1? Error: No input directory given.}
+OUTPUT_DIR=${2:-$INPUT_DIR}
+
+ABS_PATH=$(realpath $INPUT_DIR)
+
+if [[ ! -d $ABS_PATH ]]; then
+    echo "Directory $ABS_PATH does not exist."
+    exit 1
+fi
+
+echo "Converting DICOM stacks to VTK..."
+for d in $(find $ABS_PATH -maxdepth 1 -type d); do
+    python dicom-to-vtk.py -i $d -o $OUTPUT_DIR
+done
+
+echo "Finished converting DICOM stacks to VTK."

--- a/dicom-to-vti/python/dicom-to-vtk.py
+++ b/dicom-to-vti/python/dicom-to-vtk.py
@@ -1,40 +1,63 @@
 #!/usr/bin/env python
-'''Convert a DICOM image series into a VTK .vtk image file.
 
-   Usage: 
+# ###########################################################
+# Convert a DICOM image series into a VTK .vtk image file.
+#
+#   Usage:
+#
+#     dicom-to-vtk.py -i <DICOM_DIRECTORY> -o <VTK_DIRECTORY>
+#
+# ###########################################################
 
-     dicom-to-vtk.py DICOM_DIRECTORY
-
-'''
-import os
-from pathlib import Path
+import argparse
 import sys 
 import SimpleITK as sitk
 
-data_directory = sys.argv[1]
-series_IDs = sitk.ImageSeriesReader.GetGDCMSeriesIDs(data_directory)
 
-if not series_IDs:
-    print("ERROR: given directory \""+data_directory+"\" does not contain a DICOM series.")
-    sys.exit(1)
-print("DICOM series_IDs: " + str(series_IDs))
+def main(data_directory, output_directory):
 
-## Get the series file names.
-#
-series_file_names = sitk.ImageSeriesReader.GetGDCMSeriesFileNames(data_directory, series_IDs[0])
-series_reader = sitk.ImageSeriesReader()
-series_reader.SetFileNames(series_file_names)
-print("Number of series file names: {0:d}".format(len(series_file_names)))
+    series_IDs = sitk.ImageSeriesReader.GetGDCMSeriesIDs(data_directory)
 
-## Configure the reader to load all of the DICOM tags (public+private):
-#
-series_reader.MetaDataDictionaryArrayUpdateOn()
-series_reader.LoadPrivateTagsOn()
-image3D = series_reader.Execute()
+    if not series_IDs:
+        print("ERROR: given directory \"" + data_directory + "\" does not contain a DICOM series.")
+        sys.exit(1)
+    print("DICOM series_IDs: " + str(series_IDs))
 
-## Write the .vtk file.
-#
-writer = sitk.ImageFileWriter()
-writer.SetFileName("volume.vtk")
-writer.Execute(image3D)
+    # Get the series file names
+    series_file_names = sitk.ImageSeriesReader.GetGDCMSeriesFileNames(data_directory, series_IDs[0])
+    series_reader = sitk.ImageSeriesReader()
+    series_reader.SetFileNames(series_file_names)
+    print("Number of series file names: {0:d}".format(len(series_file_names)))
 
+    # Configure the reader to load all of the DICOM tags (public+private)
+    series_reader.MetaDataDictionaryArrayUpdateOn()
+    series_reader.LoadPrivateTagsOn()
+    image3D = series_reader.Execute()
+
+    # Write the .vtk file
+    basename = data_directory.split('/')[-1]
+    writer = sitk.ImageFileWriter()
+    writer.SetFileName(output_directory + "/" + basename + ".vtk")
+    writer.Execute(image3D)
+
+
+if __name__ == "__main__":
+
+    arg_parser = argparse.ArgumentParser(description="Convert DICOM image series into a VTK .vtk image series")
+
+    arg_parser.add_argument(
+        "-i",
+        dest="data_directory",
+        required=True,
+        help="Top-level directory containing subdirectories of DICOM series."
+    )
+    arg_parser.add_argument(
+        "-o",
+        dest="output_directory",
+        required=True,
+        help="Output file directory."
+    )
+
+    args = arg_parser.parse_args()
+
+    main(args.data_directory, args.output_directory)


### PR DESCRIPTION
dicom-to-vtk takes input (DICOM) directory and output (VTK) directory as arguments. Bash script batch_dicom2vtk runs dicom-to-vtk for all DICOM series contained in a parent directory.